### PR TITLE
Use relative path to icon images

### DIFF
--- a/templates/plugins/modifier.reviewsShowStars.php
+++ b/templates/plugins/modifier.reviewsShowStars.php
@@ -28,52 +28,52 @@ function smarty_modifier_reviewsShowStars($score)
     {
         case (10):
             for ($i = 1; $i < 11; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (9):
             for ($i = 1; $i < 10; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (8):
             for ($i = 1; $i < 9; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (7):
             for ($i = 1; $i < 8; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (6):
             for ($i = 1; $i < 7; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (5):
             for ($i = 1; $i < 6; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (4):
             for ($i = 1; $i < 5; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (3):
             for ($i = 1; $i < 4; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (2):
             for ($i = 1; $i < 3; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
         case (1):
             for ($i = 1; $i < 2; $i++) {
-                $result .= "<img src='/images/icons/extrasmall/favorites.png' />";
+                $result .= "<img src='images/icons/extrasmall/favorites.png' />";
             }
             break;
 


### PR DESCRIPTION
The icon images for ratings should be addressed with relative paths. With this they will be shown correctly even if Zikula is installed in a subdirectory on the server.
